### PR TITLE
make_conn_and_chan: call rand_compat:seed before uniform

### DIFF
--- a/src/rabbit_shovel_worker.erl
+++ b/src/rabbit_shovel_worker.erl
@@ -228,6 +228,7 @@ publish(Tag, Method, Msg,
       end).
 
 make_conn_and_chan(URIs) ->
+    rand_compat:seed(erlang:now()),
     URI = lists:nth(rand_compat:uniform(length(URIs)), URIs),
     {ok, AmqpParam} = amqp_uri:parse(URI),
     {ok, Conn} = amqp_connection:start(AmqpParam),


### PR DESCRIPTION
As rand_compat isn't first seeded the same 'random' number is being returned on every call to `rand_compat:uniform`. The result of this is that if the current source or dest node goes down (and the shovel is running on a different node) the make_conn_and_chan continues to return the same URI, which now isn't available, breaking the shovel and showing the following error on the shovel status web page, even though there are still other nodes available
```
{{badmatch,{error,econnrefused}},
 [{rabbit_shovel_worker,make_conn_and_chan,1,
                        [{file,"src/rabbit_shovel_worker.erl"},{line,233}]},
  {rabbit_shovel_worker,handle_cast,2,
                        [{file,"src/rabbit_shovel_worker.erl"},{line,59}]},
  {gen_server2,handle_msg,2,[{file,"src/gen_server2.erl"},{line,1032}]},
  {proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,237}]}]}
```

the master branch already fixes this by switching to `rand` which doesn't require seeding but as this isn't available before erlang v18 and rabbit 3.6 supports v17 a different fix is needed. By calling `rand_compat:seed(erlang:now())` before `rand:uniform` the seed is different every call and thus a different random number of URI index is returned each time.

