### PR TITLE
Make dynamic Shovel definition validation support maps

### DIFF
--- a/src/rabbit_shovel_dyn_worker_sup.erl
+++ b/src/rabbit_shovel_dyn_worker_sup.erl
@@ -30,7 +30,8 @@ start_link(Name, Config) ->
 
 %%----------------------------------------------------------------------------
 
-init([Name, Config]) ->
+init([Name, Config0]) ->
+    Config = rabbit_data_coercion:to_proplist(Config0),
     {ok, {{one_for_one, 1, ?MAX_WAIT},
           [{Name,
             {rabbit_shovel_worker, start_link, [dynamic, Name, Config]},

--- a/src/rabbit_shovel_parameters.erl
+++ b/src/rabbit_shovel_parameters.erl
@@ -38,7 +38,8 @@ register() ->
 unregister() ->
     rabbit_registry:unregister(runtime_parameter, <<"shovel">>).
 
-validate(_VHost, <<"shovel">>, Name, Def, User) ->
+validate(_VHost, <<"shovel">>, Name, Def0, User) ->
+    Def = rabbit_data_coercion:to_proplist(Def0),
     Validations =
         shovel_validation()
         ++ src_validation(Def, User)
@@ -207,13 +208,15 @@ validate_delete_after(Name,  Term) ->
     {error, "~s should be number, \"never\" or \"queue-length\", actually was "
      "~p", [Name, Term]}.
 
-validate_amqp10_map(Name, Terms) ->
+validate_amqp10_map(Name, Terms0) ->
+    Terms = rabbit_data_coercion:to_proplist(Terms0),
     Str = fun rabbit_parameter_validation:binary/2,
     Validation = [{K, Str, optional} || {K, _} <- Terms],
     rabbit_parameter_validation:proplist(Name, Validation, Terms).
 
 %% TODO headers?
-validate_properties(Name, Term) ->
+validate_properties(Name, Term0) ->
+    Term = rabbit_data_coercion:to_proplist(Term0),
     Str = fun rabbit_parameter_validation:binary/2,
     Num = fun rabbit_parameter_validation:number/2,
     rabbit_parameter_validation:proplist(
@@ -426,7 +429,8 @@ set_properties(Props, []) ->
 set_properties(Props, [{Ix, V} | Rest]) ->
     set_properties(setelement(Ix, Props, V), Rest).
 
-lookup_indices(KVs, L) ->
+lookup_indices(KVs0, L) ->
+    KVs = rabbit_data_coercion:to_proplist(KVs0),
     [{1 + list_find(list_to_atom(binary_to_list(K)), L), V} || {K, V} <- KVs].
 
 list_find(K, L) -> list_find(K, L, 1).

--- a/test/parameters_SUITE.erl
+++ b/test/parameters_SUITE.erl
@@ -40,7 +40,8 @@ groups() ->
           parse_amqp091_legacy,
           parse_amqp10,
           parse_amqp10_minimal,
-          validate_amqp10
+          validate_amqp10,
+          validate_amqp10_with_a_map
         ]}
     ].
 
@@ -77,8 +78,8 @@ parse_amqp091_legacy(_Config) ->
          {<<"dest-uri">>, <<"amqp://remotehost:5672">>},
          {<<"add-forward-headers">>, true},
          {<<"add-timestamp-header">>, true},
-         {<<"publish-properties">>, [{<<"cluster_id">>, <<"x">>},
-                                     {<<"delivery_mode">>, 2}]},
+         {<<"publish-properties">>, #{<<"cluster_id">> => <<"x">>,
+                                      <<"delivery_mode">> => 2}},
          {<<"ack-mode">>, <<"on-publish">>},
          {<<"delete-after">>, <<"queue-length">>},
          {<<"prefetch-count">>, 30},
@@ -250,6 +251,34 @@ validate_amqp10(_Config) ->
                                                <<"message-ann-value">>}]},
          {<<"dest-properties">>, [{<<"user_id">>, <<"some-user">>}]}
         ],
+
+        Res = rabbit_shovel_parameters:validate("my-vhost", <<"shovel">>,
+                                                "my-shovel", Params, none),
+        [] = validate_ok(Res),
+        ok.
+
+validate_amqp10_with_a_map(_Config) ->
+    Params =
+        #{
+         <<"ack-mode">> => <<"on-publish">>,
+         <<"reconnect-delay">> => 1001,
+
+         <<"src-protocol">> => <<"amqp10">>,
+         <<"src-uri">> => <<"amqp://localhost:5672">>,
+         <<"src-address">> => <<"a-src-queue">>,
+         <<"src-delete-after">> => <<"never">>,
+         <<"src-prefetch-count">> => 30,
+
+         <<"dest-protocol">> => <<"amqp10">>,
+         <<"dest-uri">> => <<"amqp://remotehost:5672">>,
+         <<"dest-address">> => <<"a-dest-queue">>,
+         <<"dest-add-forward-headers">> => true,
+         <<"dest-add-timestamp-header">> => true,
+         <<"dest-application-properties">> => [{<<"some-app-prop">>,
+                                                <<"app-prop-value">>}],
+         <<"dest-message-annotations">> => [{<<"some-message-ann">>, <<"message-ann-value">>}],
+         <<"dest-properties">> => #{<<"user_id">> => <<"some-user">>}
+        },
 
         Res = rabbit_shovel_parameters:validate("my-vhost", <<"shovel">>,
                                                 "my-shovel", Params, none),


### PR DESCRIPTION
## Proposed Changes

This makes dynamic Shovel definition work with the 3.7.x JSON parser which produces maps,
e.g.

``` shell
rabbitmqctl set_parameter -p vhost1 shovel persistent_d '{"src-uri": "amqp://user:pass@rabbitmq.lll.com/vhost1" , "src-queue": "queue1","dest-uri": "amqp://user:pass@rabbitmq.lll.com/vhost1", "dest-queue": "queue2","publish-properties":{"delivery_mode":2}}'
```

should now work. See #38 for background. Note that the original rabbitmq-users report
contains an incorrect definition that would fail even with this PR but with a more sensible and specific error: a particular value, `publish-properties` is incorrect.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

Closes #38.
[#156367916]
