### PR TITLE
Remove unused macros since AMQP-1.0 support

### DIFF
--- a/src/rabbit_shovel_config.erl
+++ b/src/rabbit_shovel_config.erl
@@ -22,9 +22,6 @@
 -include_lib("amqp_client/include/amqp_client.hrl").
 -include("rabbit_shovel.hrl").
 
--define(IGNORE_FIELDS, [delete_after]).
--define(EXTRA_KEYS, [add_forward_headers, add_timestamp_header]).
-
 resolve_module(amqp091) -> rabbit_amqp091_shovel;
 resolve_module(amqp10) -> rabbit_amqp10_shovel.
 


### PR DESCRIPTION
## Proposed Changes

Shovel used to use `IGNORE_FIELDS`  and `EXTRA_KEYS`  macros to pre-initialize `#shovel{}` & filter user defined config. These are no longer in use since AMQP-1.0 support was introduced.

## Types of Changes

- [x] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [x] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
