### PR TITLE
Handle amqp encoded body values.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ dep_amqp10_client = git https://github.com/rabbitmq/rabbitmq-amqp1.0-client.git 
 
 LOCAL_DEPS = crypto
 
-TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers rabbitmq_amqp1_0
+TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers rabbitmq_amqp1_0 meck
 
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk elvis_mk

--- a/src/rabbit_amqp10_shovel.erl
+++ b/src/rabbit_amqp10_shovel.erl
@@ -186,7 +186,7 @@ dest_endpoint(#{shovel_type := dynamic,
 -spec handle_source(Msg :: any(), state()) -> not_handled | state().
 handle_source({amqp10_msg, _LinkRef, Msg}, State) ->
     Tag = amqp10_msg:delivery_id(Msg),
-    [Payload] = amqp10_msg:body(Msg),
+    Payload = amqp10_msg:body_bin(Msg),
     rabbit_shovel_behaviour:forward(Tag, #{}, Payload, State);
 handle_source({amqp10_event, {connection, Conn, opened}},
               State = #{source := #{current := #{conn := Conn}}}) ->

--- a/test/amqp10_SUITE.erl
+++ b/test/amqp10_SUITE.erl
@@ -219,6 +219,27 @@ setup_amqp10_destination_shovel(Config, Queue, AckMode) ->
                 {ack_mode, AckMode}]}],
     ok = rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, setup_shovel,
                                       [Shovel]).
+setup_amqp10_shovel(Config, SourceQueue, DestQueue, AckMode) ->
+    Hostname = ?config(rmq_hostname, Config),
+    Port = rabbit_ct_broker_helpers:get_node_config(Config, 0, tcp_port_amqp),
+    Shovel = [{test_shovel,
+               [{source,
+                 [{protocol, amqp10},
+                  {uris, [rabbit_misc:format("amqp://~s:~b",
+                                             [Hostname, Port])]},
+                  {source_address, SourceQueue}]},
+                {destination,
+                 [{protocol, amqp10},
+                  {uris, [rabbit_misc:format("amqp://~s:~b",
+                                             [Hostname, Port])]},
+                  {add_forward_headers, true},
+                  {add_timestamp_header, true},
+                  {target_address, DestQueue}]
+                },
+                {ack_mode, AckMode}]}],
+    ok = rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, setup_shovel,
+                                      [Shovel]).
+
 setup_shovel(ShovelConfig) ->
     _ = application:stop(rabbitmq_shovel),
     application:set_env(rabbitmq_shovel, shovels, ShovelConfig, infinity),

--- a/test/amqp10_shovel_SUITE.erl
+++ b/test/amqp10_shovel_SUITE.erl
@@ -1,0 +1,95 @@
+-module(amqp10_shovel_SUITE).
+
+-compile(export_all).
+
+-export([
+         ]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("amqp10_common/include/amqp10_framing.hrl").
+
+%%%===================================================================
+%%% Common Test callbacks
+%%%===================================================================
+
+all() ->
+    [
+     {group, tests}
+    ].
+
+
+all_tests() ->
+    [
+     amqp_encoded_data_list,
+     amqp_encoded_amqp_value
+    ].
+
+groups() ->
+    [
+     {tests, [], all_tests()}
+    ].
+
+init_per_suite(Config) ->
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+init_per_group(_Group, Config) ->
+    Config.
+
+end_per_group(_Group, _Config) ->
+    ok.
+
+init_per_testcase(_TestCase, Config) ->
+    Config.
+
+end_per_testcase(_TestCase, _Config) ->
+    meck:unload(),
+    ok.
+
+%%%===================================================================
+%%% Test cases
+%%%===================================================================
+
+amqp_encoded_data_list(_Config) ->
+    meck:new(rabbit_shovel_behaviour, [passthrough]),
+    meck:expect(rabbit_shovel_behaviour, forward,
+                fun (_, _, Pay, S) ->
+                        ?assert(erlang:is_binary(Pay)),
+                        S
+                end),
+    %% fake some shovel state
+    State = #{source => #{},
+              dest => #{module => rabbit_amqp10_shovel},
+              ack_mode => no_ack},
+    Body = [
+            #'v1_0.data'{content = <<"one">>},
+            #'v1_0.data'{content = <<"two">>}
+           ],
+    Msg = amqp10_msg:new(55, Body),
+    rabbit_amqp10_shovel:handle_source({amqp10_msg, linkref, Msg}, State),
+
+    ?assert(meck:validate(rabbit_shovel_behaviour)),
+    ok.
+
+amqp_encoded_amqp_value(_Config) ->
+    meck:new(rabbit_shovel_behaviour, [passthrough]),
+    meck:expect(rabbit_shovel_behaviour, forward,
+                fun (_, _, Pay, S) ->
+                        ?assert(erlang:is_binary(Pay)),
+                        S
+                end),
+    %% fake some shovel state
+    State = #{source => #{},
+              dest => #{module => rabbit_amqp10_shovel},
+              ack_mode => no_ack},
+    Body = #'v1_0.amqp_value'{content = {utf8, <<"hi">>}},
+    Msg = amqp10_msg:new(55, Body),
+    rabbit_amqp10_shovel:handle_source({amqp10_msg, linkref, Msg}, State),
+
+    ?assert(meck:validate(rabbit_shovel_behaviour)),
+    ok.
+
+%% Utility


### PR DESCRIPTION
Use new amqp10_msg:body_bin to get a binary representation of the amqp
1.0 encoded body.

[#159434026]

Fixes #42 

Requires: https://github.com/rabbitmq/rabbitmq-amqp1.0-client/pull/22