### PR TITLE
Extra tests that set up Shovels with blank publish properties

### DIFF
--- a/test/dynamic_SUITE.erl
+++ b/test/dynamic_SUITE.erl
@@ -30,7 +30,10 @@ groups() ->
     [
       {non_parallel_tests, [], [
           simple,
-          set_properties,
+          set_properties_using_proplist,
+          set_properties_using_map,
+          set_empty_properties_using_proplist,
+          set_empty_properties_using_map,
           headers,
           exchange,
           restart,
@@ -86,7 +89,19 @@ simple(Config) ->
               publish_expect(Ch, <<>>, <<"src">>, <<"dest">>, <<"hello">>)
       end).
 
-set_properties(Config) ->
+set_properties_using_map(Config) ->
+    with_ch(Config,
+      fun (Ch) ->
+              Ps = [{<<"src-queue">>,      <<"src">>},
+                    {<<"dest-queue">>,     <<"dest">>},
+                    {<<"publish-properties">>, #{<<"cluster_id">> => <<"x">>}}],
+              shovel_test_utils:set_param(Config, <<"test">>, Ps),
+              #amqp_msg{props = #'P_basic'{cluster_id = Cluster}} =
+                  publish_expect(Ch, <<>>, <<"src">>, <<"dest">>, <<"hi">>),
+              <<"x">> = Cluster
+      end).
+
+set_properties_using_proplist(Config) ->
     with_ch(Config,
       fun (Ch) ->
               Ps = [{<<"src-queue">>,      <<"src">>},
@@ -96,6 +111,28 @@ set_properties(Config) ->
               #amqp_msg{props = #'P_basic'{cluster_id = Cluster}} =
                   publish_expect(Ch, <<>>, <<"src">>, <<"dest">>, <<"hi">>),
               <<"x">> = Cluster
+      end).
+
+set_empty_properties_using_map(Config) ->
+    with_ch(Config,
+      fun (Ch) ->
+              Ps = [{<<"src-queue">>,      <<"src">>},
+                    {<<"dest-queue">>,     <<"dest">>},
+                    {<<"publish-properties">>, #{}}],
+              shovel_test_utils:set_param(Config, <<"test">>, Ps),
+              #amqp_msg{props = #'P_basic'{}} =
+                  publish_expect(Ch, <<>>, <<"src">>, <<"dest">>, <<"hi">>)
+      end).
+
+set_empty_properties_using_proplist(Config) ->
+    with_ch(Config,
+      fun (Ch) ->
+              Ps = [{<<"src-queue">>,      <<"src">>},
+                    {<<"dest-queue">>,     <<"dest">>},
+                    {<<"publish-properties">>, []}],
+              shovel_test_utils:set_param(Config, <<"test">>, Ps),
+              #amqp_msg{props = #'P_basic'{}} =
+                  publish_expect(Ch, <<>>, <<"src">>, <<"dest">>, <<"hi">>)
       end).
 
 headers(Config) ->


### PR DESCRIPTION
## Proposed Changes

This provides additional tests for #46, which has been addressed in 2d73d979e20bd1b8c25aaf08ce01f733abf653e8 in master but only recently backported to `v3.7.x`.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #46)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

To reproduce #46, run a local 3.7.9 node with `rabbitmq_shovel_management` enabled then tail its logs and run

``` bash
curl -u guest:guest -X DELETE http://localhost:15672/api/parameters/shovel/%2F/s1
curl -u guest:guest -X PUT http://localhost:15672/api/parameters/shovel/%2F/s1 --data '{"component":"shovel","vhost":"/","name":"s1","value":{"src-uri":"amqp://","dest-uri":"amqp://","ack-mode":"on-confirm","src-protocol":"amqp091","dest-protocol":"amqp091","src-queue":"shovel-src","src-delete-after":"never","dest-queue":"shovel-dst","dest-add-forward-headers":false, "publish-properties": {}}}'
```

there will be exceptions in the log and the Shovel will fail to start.

In master and the tip of `v3.7.x` there should be no
exceptions and the Shovel should start successfully, which you will be able to observe in
the Admin => Shovel management section of the management UI.

This PR simply adds some tests that use blank publish properties.

After you are done with testing, delete the now successfully created Shovel:

``` bash
curl -u guest:guest -X DELETE http://localhost:15672/api/parameters/shovel/%2F/s1
```