### PR TITLE
Make rabbit_shovel_dyn_worker_sup_sup:start_link/0 idempotent

### DIFF
--- a/src/rabbit_shovel_dyn_worker_sup_sup.erl
+++ b/src/rabbit_shovel_dyn_worker_sup_sup.erl
@@ -26,9 +26,12 @@
 -define(SUPERVISOR, ?MODULE).
 
 start_link() ->
-    {ok, Pid} = mirrored_supervisor:start_link(
+    Pid = case mirrored_supervisor:start_link(
                   {local, ?SUPERVISOR}, ?SUPERVISOR,
-                  fun rabbit_misc:execute_mnesia_transaction/1, ?MODULE, []),
+                  fun rabbit_misc:execute_mnesia_transaction/1, ?MODULE, []) of
+            {ok, Pid0}                       -> Pid0;
+            {error, {already_started, Pid0}} -> Pid0
+          end,
     Shovels = rabbit_runtime_parameters:list_component(<<"shovel">>),
     [start_child({pget(vhost, Shovel), pget(name, Shovel)},
                  pget(value, Shovel)) || Shovel <- Shovels],


### PR DESCRIPTION
## Proposed Changes

This allows for a very rudimentary way of restarting a Shovel: stopping it with `stop_child/2` and
starting all of them using the otherwise idempotent `start_link/0`.

## Types of Changes

- [x] Bug fix (non-breaking change which references issue #48)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

References #48.