### PR TITLE
Improve amqp 1.0 error handling

### DIFF
--- a/src/rabbit_shovel_worker.erl
+++ b/src/rabbit_shovel_worker.erl
@@ -113,9 +113,9 @@ terminate({shutdown, autodelete}, State = #state{name = {VHost, Name},
     ok;
 terminate(Reason, State) ->
     error_logger:info_msg("terminating static worker with ~p ~n", [Reason]),
-    close_connections(State),
     rabbit_shovel_status:report(State#state.name, State#state.type,
                                 {terminated, Reason}),
+    close_connections(State),
     ok.
 
 code_change(_OldVsn, State, _Extra) ->


### PR DESCRIPTION
Firstly avoid the explicit receive on connection to wait for link
credit. Instead we cache any early forward operations until link credit
has been received.This way any early close events are handled by the
existing callbacks.

Also wait and link the connection process until after the session
process has been started. The session process isn't started until the
sasl handshake has completed. If we link before this and sasl
authenticatio fails the shovel will not report the correct error.

Also write the report update earlier in the terminate function of the
worker.

requires: https://github.com/rabbitmq/rabbitmq-amqp1.0/pull/85