### PR TITLE
Call rabbit_access_control:check_vhost_access with empty context

### DIFF
--- a/src/rabbit_shovel_parameters.erl
+++ b/src/rabbit_shovel_parameters.erl
@@ -194,7 +194,7 @@ validate_params_user(#amqp_params_direct{virtual_host = VHost},
                      User = #user{username = Username}) ->
     case rabbit_vhost:exists(VHost) andalso
         (catch rabbit_access_control:check_vhost_access(
-                 User, VHost, undefined)) of
+                 User, VHost, undefined, #{})) of
         ok -> ok;
         _  -> {error, "user \"~s\" may not connect to vhost \"~s\"",
                   [Username, VHost]}


### PR DESCRIPTION
Nothing much to propagate here.

References rabbitmq/rabbitmq-server#1767