### PR TITLE
Rework Shovel restarts

### DIFF
--- a/src/rabbit_amqp091_shovel.erl
+++ b/src/rabbit_amqp091_shovel.erl
@@ -250,8 +250,7 @@ handle_dest(#'basic.nack'{delivery_tag = Seq, multiple = Multiple},
                        end, Seq, Multiple, State);
 
 handle_dest(#'basic.cancel'{}, #{name := Name}) ->
-    rabbit_log:warning("Shovel ~p received 'basic.cancel' from the broker~n",
-                       [Name]),
+    rabbit_log:warning("Shovel ~p received a 'basic.cancel' from the server", [Name]),
     {stop, {shutdown, restart}};
 
 handle_dest({'EXIT', Conn, Reason}, #{dest := #{current := {Conn, _, _}}}) ->
@@ -314,12 +313,12 @@ publish(IncomingTag, Method, Msg,
 
 make_conn_and_chan([], {VHost, Name} = _ShovelName) ->
     rabbit_log:error(
-          "Shovel '~s' in vhost '~s' has no more URIs to try for connection and will terminate~n",
+          "Shovel '~s' in vhost '~s' has no more URIs to try for connection",
           [Name, VHost]),
     erlang:error(failed_to_connect_using_provided_uris);
 make_conn_and_chan([], ShovelName) ->
     rabbit_log:error(
-          "Shovel '~s' has no more URIs to try for connection and will terminate~n",
+          "Shovel '~s' has no more URIs to try for connection",
           [ShovelName]),
     erlang:error(failed_to_connect_using_provided_uris);
 make_conn_and_chan(URIs, ShovelName) ->

--- a/src/rabbit_shovel_dyn_worker_sup.erl
+++ b/src/rabbit_shovel_dyn_worker_sup.erl
@@ -43,7 +43,8 @@ init([Name, Config0]) ->
             %% always try to reconnect
             <<"never">>                        -> {permanent, N};
             %% this Shovel is an autodelete one
-            M when is_integer(M) andalso M > 0 -> {transient, N}
+              M when is_integer(M) andalso M > 0 -> {transient, N};
+              <<"queue-length">> -> {transient, N}
           end;
         %% reconnect-delay = 0 means "do not reconnect"
         _                                  -> temporary

--- a/src/rabbit_shovel_worker.erl
+++ b/src/rabbit_shovel_worker.erl
@@ -44,7 +44,6 @@ start_link(Type, Name, Config) ->
 %%---------------------------
 
 init([Type, Name, Config0]) ->
-    gen_server2:cast(self(), init),
     Config = case Type of
                 static ->
                      Config0;
@@ -55,22 +54,51 @@ init([Type, Name, Config0]) ->
                                                                 Config0),
                     Conf
             end,
+    case Name of
+      {VHost, ShovelName} -> rabbit_log:debug("Initialising a Shovel '~s' of type '~s' in virtual host '~s'", [ShovelName, Type, VHost]);
+      ShovelName          -> rabbit_log:debug("Initialising a Shovel '~s' of type '~s'", [ShovelName, Type])
+    end,
+    gen_server2:cast(self(), init),
     {ok, #state{name = Name, type = Type, config = Config}}.
 
 handle_call(_Msg, _From, State) ->
     {noreply, State}.
 
 handle_cast(init, State = #state{config = Config0}) ->
-    Config = rabbit_shovel_behaviour:connect_source(Config0),
-    %% this makes sure that connection pid is updated in case
-    %% any of the subsequent connection/init steps fail. See
-    %% rabbitmq/rabbitmq-shovel#54 for context.
-    gen_server2:cast(self(), connect_dest),
-    {noreply, State#state{config = Config}};
+    try rabbit_shovel_behaviour:connect_source(Config0) of
+      Config ->
+        case maps:get(name, Config) of
+          {VHost, ShovelName} -> rabbit_log:debug("Shovel '~s' in virtual host '~s' connected to source", [ShovelName, VHost]);
+          ShovelName          -> rabbit_log:debug("Shovel '~s' connected to source", [ShovelName])
+        end,
+        %% this makes sure that connection pid is updated in case
+        %% any of the subsequent connection/init steps fail. See
+        %% rabbitmq/rabbitmq-shovel#54 for context.
+        gen_server2:cast(self(), connect_dest),
+        {noreply, State#state{config = Config}}
+    catch _:_ ->
+      case maps:get(name, Config0) of
+        {VHost, ShovelName} -> rabbit_log:error("Shovel '~s' in virtual host '~s' failed to connect to source", [ShovelName, VHost]);
+        ShovelName          -> rabbit_log:error("Shovel '~s' failed to connect to source", [ShovelName])
+      end,
+      {stop, shutdown, State}
+    end;
 handle_cast(connect_dest, State = #state{config = Config0}) ->
-    Config = rabbit_shovel_behaviour:connect_dest(Config0),
-    gen_server2:cast(self(), init_shovel),
-    {noreply, State#state{config = Config}};
+    try rabbit_shovel_behaviour:connect_dest(Config0) of
+      Config ->
+        case maps:get(name, Config) of
+          {VHost, ShovelName} -> rabbit_log:debug("Shovel '~s' in virtual host '~s' connected to destination", [ShovelName, VHost]);
+          ShovelName          -> rabbit_log:debug("Shovel '~s' connected to destination", [ShovelName])
+        end,
+        gen_server2:cast(self(), init_shovel),
+        {noreply, State#state{config = Config}}
+    catch _:_ ->
+      case maps:get(name, Config0) of
+        {VHost, ShovelName} -> rabbit_log:error("Shovel '~s' in virtual host '~s' failed to connect to destination", [ShovelName, VHost]);
+        ShovelName          -> rabbit_log:error("Shovel '~s' failed to connect to destination", [ShovelName])
+      end,
+      {stop, shutdown, State}
+    end;
 handle_cast(init_shovel, State = #state{config = Config}) ->
     %% Don't trap exits until we have established connections so that
     %% if we try to shut down while waiting for a connection to be
@@ -78,6 +106,10 @@ handle_cast(init_shovel, State = #state{config = Config}) ->
     process_flag(trap_exit, true),
     Config1 = rabbit_shovel_behaviour:init_dest(Config),
     Config2 = rabbit_shovel_behaviour:init_source(Config1),
+    case maps:get(name, Config2) of
+      {VHost, ShovelName} -> rabbit_log:debug("Shovel '~s' in virtual host '~s' has finished setting up its topology", [ShovelName, VHost]);
+      ShovelName          -> rabbit_log:debug("Shovel '~s' has finished setting up its topology", [ShovelName])
+    end,
     State1 = State#state{config = Config2},
     ok = report_running(State1),
     {noreply, State1}.
@@ -88,15 +120,37 @@ handle_info(Msg, State = #state{config = Config, name = Name}) ->
         not_handled ->
             case rabbit_shovel_behaviour:handle_dest(Msg, Config) of
                 not_handled ->
-                    error_logger:info_msg("Shovel ~p message not handled! ~p~n",
-                                          [Name, Msg]),
+                    case Name of
+                      {VHost, ShovelName} -> rabbit_log:warning("Shovel '~s' in virtual host '~s' could not handle a destination message ~p", [ShovelName, VHost, Msg]);
+                      ShovelName          -> rabbit_log:warning("Shovel '~s' could not handle a destination message ~p", [ShovelName, Msg])
+                    end,
                     {noreply, State};
+                {stop, {outbound_conn_died, Reason}} ->
+                    case Name of
+                      {VHost, ShovelName} -> rabbit_log:error("Shovel '~s' in virtual host '~s' detected destination connection failure", [ShovelName, VHost]);
+                      ShovelName          -> rabbit_log:error("Shovel '~s' detected destination connection failure", [ShovelName])
+                    end,
+                    {stop, Reason, State};
                 {stop, Reason} ->
+                    case Name of
+                      {VHost, ShovelName} -> rabbit_log:debug("Shovel '~s' in virtual host '~s' decided to stop due a message from destination: ~p", [ShovelName, VHost, Msg]);
+                      ShovelName          -> rabbit_log:debug("Shovel '~s' decided to stop due a message from destination: ~p", [ShovelName, Msg])
+                    end,
                     {stop, Reason, State};
                 Config1 ->
                     {noreply, State#state{config = Config1}}
             end;
+        {stop, {inbound_conn_died, Reason}} ->
+            case Name of
+              {VHost, ShovelName} -> rabbit_log:error("Shovel '~s' in virtual host '~s' detected source connection failure", [ShovelName, VHost, Msg]);
+              ShovelName          -> rabbit_log:error("Shovel '~s' detected source connection failure: ~p", [ShovelName, Msg])
+            end,
+            {stop, Reason, State};
         {stop, Reason} ->
+            case Name of
+              {VHost, ShovelName} -> rabbit_log:debug("Shovel '~s' in virtual host '~s' decided to stop due a message from source: ~p", [ShovelName, VHost, Msg]);
+              ShovelName          -> rabbit_log:debug("Shovel '~s' decided to stop due a message from source: ~p", [ShovelName, Msg])
+            end,
             {stop, Reason, State};
         Config1 ->
             {noreply, State#state{config = Config1}}
@@ -104,21 +158,57 @@ handle_info(Msg, State = #state{config = Config, name = Name}) ->
 
 terminate({shutdown, autodelete}, State = #state{name = {VHost, Name},
                                                  type = dynamic}) ->
-    error_logger:info_msg("Shovel '~s' in virtual host '~s' is stopping (it was configured to autodelete and transfer is completed)~n", [Name, VHost]),
+    rabbit_log:info("Shovel '~s' in virtual host '~s' is stopping (it was configured to autodelete and transfer is completed)", [Name, VHost]),
     close_connections(State),
     %% See rabbit_shovel_dyn_worker_sup_sup:stop_child/1
     put(shovel_worker_autodelete, true),
     _ = rabbit_runtime_parameters:clear(VHost, <<"shovel">>, Name, ?SHOVEL_USER),
     rabbit_shovel_status:remove({VHost, Name}),
     ok;
+terminate(shutdown, State) ->
+    close_connections(State),
+    ok;
+terminate(shutdown, State) ->
+    close_connections(State),
+    ok;
+terminate(socket_closed_unexpectedly, State) ->
+    close_connections(State),
+    ok;
+terminate(socket_closed_unexpectedly, State) ->
+    close_connections(State),
+    ok;
+terminate({'EXIT', outbound_conn_died}, State = #state{name = {VHost, Name}}) ->
+    rabbit_log:error("Shovel '~s' in virtual host '~s' is stopping because destination connection failed", [Name, VHost]),
+    rabbit_shovel_status:report(State#state.name, State#state.type,
+                                {terminated, "destination connection failed"}),
+    close_connections(State),
+    ok;
+terminate({'EXIT', outbound_conn_died}, State = #state{name = Name}) ->
+    rabbit_log:error("Shovel '~s' is stopping because destination connection failed", [Name]),
+    rabbit_shovel_status:report(State#state.name, State#state.type,
+                                {terminated, "destination connection failed"}),
+    close_connections(State),
+    ok;
+terminate({'EXIT', inbound_conn_died}, State = #state{name = {VHost, Name}}) ->
+    rabbit_log:error("Shovel '~s' in virtual host '~s' is stopping because destination connection failed", [Name, VHost]),
+    rabbit_shovel_status:report(State#state.name, State#state.type,
+                                {terminated, "source connection failed"}),
+    close_connections(State),
+    ok;
+terminate({'EXIT', inbound_conn_died}, State = #state{name = Name}) ->
+    rabbit_log:error("Shovel '~s' is stopping because source connection failed", [Name]),
+    rabbit_shovel_status:report(State#state.name, State#state.type,
+                                {terminated, "destination connection failed"}),
+    close_connections(State),
+    ok;
 terminate(Reason, State = #state{name = {VHost, Name}}) ->
-    error_logger:info_msg("Shovel '~s' in virtual host '~s' is stopping, reason: ~p~n", [Name, VHost, Reason]),
+    rabbit_log:error("Shovel '~s' in virtual host '~s' is stopping, reason: ~p", [Name, VHost, Reason]),
     rabbit_shovel_status:report(State#state.name, State#state.type,
                                 {terminated, Reason}),
     close_connections(State),
     ok;
 terminate(Reason, State = #state{name = Name}) ->
-    error_logger:info_msg("Shovel '~s' is stopping, reason: ~p~n", [Name, Reason]),
+    rabbit_log:error("Shovel '~s' is stopping, reason: ~p", [Name, Reason]),
     rabbit_shovel_status:report(State#state.name, State#state.type,
                                 {terminated, Reason}),
     close_connections(State),

--- a/src/rabbit_shovel_worker.erl
+++ b/src/rabbit_shovel_worker.erl
@@ -198,7 +198,7 @@ terminate({'EXIT', inbound_conn_died}, State = #state{name = {VHost, Name}}) ->
 terminate({'EXIT', inbound_conn_died}, State = #state{name = Name}) ->
     rabbit_log:error("Shovel '~s' is stopping because source connection failed", [Name]),
     rabbit_shovel_status:report(State#state.name, State#state.type,
-                                {terminated, "destination connection failed"}),
+                                {terminated, "source connection failed"}),
     close_connections(State),
     ok;
 terminate(Reason, State = #state{name = {VHost, Name}}) ->


### PR DESCRIPTION
## Proposed Changes

 * Handle connection exceptions
 * More detailed logging
 * Determine whether a Shovel is autodelete one depending on `src-deleter-after`
 * Use a permanent process for regular Shovels

Previous to #54 a connection failure resulted in an exception in init/2.
After #54 that no longer happens so error handling has to be reworked.

Using a permanent process by for non-autodelete Shovels makes most sense.
Last time this decision was revisited was in 945ee177e14ba094cfb5e03824f481284f558d3d
when autodelete Shovels were introduced.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #60)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

Closes #60, references #54.

[#166627333]
